### PR TITLE
Add a mulihash encoding option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # bnid-cli ChangeLog
 
+## 2.0.0 - 2023-07-xx
+
+### Added
+- Add a multihash encoding option with a default of true.
+
+### Changed
+- **BREAKING**: Identifiers will be multibase, multihash encoded by default.
+
 ## 1.0.0 - 2022-05-13
 
 ### Added

--- a/bnid.js
+++ b/bnid.js
@@ -46,6 +46,12 @@ export async function main() {
       type: 'boolean',
       default: true
     })
+    .option('multihash', {
+      alias: 'u',
+      describe: 'Use multihash format',
+      type: 'boolean',
+      default: true
+    })
     .alias('h', 'help')
     .argv;
   try {
@@ -53,6 +59,7 @@ export async function main() {
       bitLength: args.bitLength,
       encoding: args.encoding,
       multibase: args.multibase,
+      multihash: args.multihash,
       fixedLength: args.fixedLength,
       fixedBitLength: args.fixedBitLength
     }));


### PR DESCRIPTION
This uses the command line option `u` because `m` and `h` are already allocated.  This can be adjusted if anyone has strong feelings about it.

Fixes #2 